### PR TITLE
Improve plugin structure and add type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 packages = [
     { include = "pydiagno", from = "src" },
 ]
+[tool.poetry.group.dev.dependencies]
+black = "^24.4.2"
+
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/pydiagno"

--- a/src/pydiagno/plugin.py
+++ b/src/pydiagno/plugin.py
@@ -1,0 +1,62 @@
+from typing import Optional
+import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+from _pytest.nodes import Item
+from _pytest.reports import TestReport
+from _pytest.terminal import TerminalReporter
+
+def pytest_addoption(parser: Parser) -> None:
+    """Add PyDiagno-specific command line options to pytest."""
+    group = parser.getgroup("pydiagno")
+    group.addoption(
+        "--pydiagno",
+        action="store_true",
+        dest="pydiagno",
+        default=False,
+        help="Enable PyDiagno analysis",
+    )
+
+def pytest_configure(config: Config) -> None:
+    """Configure PyDiagno plugin."""
+    config.addinivalue_line("markers", "pydiagno: mark test for PyDiagno analysis")
+    if config.getoption("pydiagno"):
+        # TODO: Initialize PyDiagno here if needed
+        pass
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: Item, call: pytest.CallInfo[None]) -> Optional[TestReport]:
+    """
+    Extend test reports with PyDiagno analysis results.
+
+    Args:
+        item: Test item being executed.
+        call: Result of test execution.
+
+    Returns:
+        Optional[TestReport]: The test report, potentially modified with PyDiagno analysis.
+    """
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when == "call":
+        marker = item.get_closest_marker("pydiagno")
+        if marker:
+            # TODO: Here we'll add the logic for PyDiagno analysis in the future
+            pass
+
+    return report
+
+def pytest_terminal_summary(terminalreporter: TerminalReporter, exitstatus: int, config: Config) -> None:
+    """
+    Add PyDiagno analysis summary to pytest output.
+
+    Args:
+        terminalreporter: Terminal reporter object.
+        exitstatus: Exit status of pytest run.
+        config: Pytest configuration object.
+    """
+    if config.getoption("pydiagno"):
+        # TODO: Here we'll add the summary of PyDiagno analysis in the future
+        terminalreporter.write_sep("-", "PyDiagno Analysis Summary")
+        terminalreporter.write_line("PyDiagno analysis summary will be added here.")

--- a/src/pydiagno/plugin.py
+++ b/src/pydiagno/plugin.py
@@ -6,6 +6,7 @@ from _pytest.nodes import Item
 from _pytest.reports import TestReport
 from _pytest.terminal import TerminalReporter
 
+
 def pytest_addoption(parser: Parser) -> None:
     """Add PyDiagno-specific command line options to pytest."""
     group = parser.getgroup("pydiagno")
@@ -17,6 +18,7 @@ def pytest_addoption(parser: Parser) -> None:
         help="Enable PyDiagno analysis",
     )
 
+
 def pytest_configure(config: Config) -> None:
     """Configure PyDiagno plugin."""
     config.addinivalue_line("markers", "pydiagno: mark test for PyDiagno analysis")
@@ -24,8 +26,11 @@ def pytest_configure(config: Config) -> None:
         # TODO: Initialize PyDiagno here if needed
         pass
 
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item: Item, call: pytest.CallInfo[None]) -> Optional[TestReport]:
+def pytest_runtest_makereport(
+    item: Item, call: pytest.CallInfo[None]
+) -> Optional[TestReport]:
     """
     Extend test reports with PyDiagno analysis results.
 
@@ -47,7 +52,10 @@ def pytest_runtest_makereport(item: Item, call: pytest.CallInfo[None]) -> Option
 
     return report
 
-def pytest_terminal_summary(terminalreporter: TerminalReporter, exitstatus: int, config: Config) -> None:
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter, exitstatus: int, config: Config
+) -> None:
     """
     Add PyDiagno analysis summary to pytest output.
 


### PR DESCRIPTION
# Improve PyDiagno Plugin Structure and Basic Implementation

## Description
This pull request improves the basic structure and implementation of the PyDiagno pytest plugin. It focuses on setting up the fundamental hooks and options required for the plugin to integrate with pytest.

## Changes
- Added `pytest_addoption` hook to include a `--pydiagno` command-line option
- Implemented `pytest_configure` hook to register the `pydiagno` marker
- Added `pytest_runtest_makereport` hook for future test result analysis
- Included `pytest_terminal_summary` hook for future analysis summary output
- Added type annotations to all functions for improved code clarity and type safety
- Included Google-style docstrings for all functions

## TODO
- Implement actual PyDiagno analysis logic in `pytest_runtest_makereport`
- Add detailed PyDiagno analysis summary in `pytest_terminal_summary`

## Testing
The basic structure has been set up, but comprehensive testing will be needed once the actual analysis logic is implemented.

## Notes
This PR sets the groundwork for the PyDiagno plugin. The TODOs indicate where future development efforts should be focused to implement the core functionality of the plugin.

## Checklist
- [x] Code follows the project's coding standards
- [x] Docstrings and type annotations are included
- [x] No unused imports
- [ ] Tests added/updated (to be done in future PRs)
- [x] Documentation updated (basic structure in place)
